### PR TITLE
fix: handle image upload errors properly

### DIFF
--- a/Release_Notes.txt
+++ b/Release_Notes.txt
@@ -2,6 +2,11 @@ CUMSA Web Application Release Notes
 -------------------------------------------------------------------
 Document all changes introduced in this release as concise bullet points below.
 
+v0.0.18 (2025-09-19)
+----------------------
+Amr Moustafa
+- added exception handling for failed image uploads with user alerts
+
 v0.0.17 (2025-09-18)
 ----------------------
 Tarek Ibrahim

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumsa-web",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "scripts": {
     "https-proxy": "local-ssl-proxy --source 3443 --target 3000 --cert certs/cert.pem --key certs/key.pem",

--- a/src/components/eventPortal/ImageManager/ImageManagerClient.tsx
+++ b/src/components/eventPortal/ImageManager/ImageManagerClient.tsx
@@ -117,6 +117,9 @@ export function ImageManagerClient({
       if (fileRef.current) fileRef.current.value = "";
       if (nameRef.current) nameRef.current.value = "";
       notify("Upload successful.");
+    } catch(error) {
+        console.error("File upload error ocurred:", error)
+        notify(error instanceof Error ? "Error: " + error.message.slice(0, error.message.indexOf("\n")) : "An error occurred during upload.");
     } finally {
       setBusy(false);
     }
@@ -187,7 +190,7 @@ export function ImageManagerClient({
   return (
     <div className="space-y-6">
       {message && (
-        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-blue-600 text-white px-4 py-2 rounded shadow-lg flex items-center gap-2">
+        <div className="fixed left-1/2 -translate-x-1/2 z-50 bg-blue-600 text-white px-4 py-2 rounded shadow-lg flex items-center gap-2" style={{ top: 'calc(var(--spacing) * 18)' }}>
           <span>{message}</span>
           <button
             onClick={() => setMessage("")}


### PR DESCRIPTION
This PR adds image upload error handling and notification displays to the user, thus catching the error properly instead of silently failing.

preview of 20MB image uploaded:

<img width="2097" height="2072" alt="image" src="https://github.com/user-attachments/assets/756b2e37-578b-4813-8316-b8d5cbc53760" />
